### PR TITLE
DM-49364: Switch AuxTel to use new ISR task

### DIFF
--- a/calib/LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z/ptc/ptc_LATISS_RXX_S00_LATISS_calib_DM-46359_isrTaskLSST_lowerSetTemp_ptcGen_20241014a_20241014T181213Z.fits
+++ b/calib/LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z/ptc/ptc_LATISS_RXX_S00_LATISS_calib_DM-46359_isrTaskLSST_lowerSetTemp_ptcGen_20241014a_20241014T181213Z.fits
@@ -1,0 +1,1 @@
+/sdf/data/rubin/repo/main_20210215/LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z/ptc/ptc_LATISS_RXX_S00_LATISS_calib_DM-46359_isrTaskLSST_lowerSetTemp_ptcGen_20241014a_20241014T181213Z.fits

--- a/calib/LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z/ptc/ptc_LATISS_RXX_S00_LATISS_calib_DM-46359_isrTaskLSST_lowerSetTemp_ptcGen_20241014a_20241014T181213Z.fits
+++ b/calib/LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z/ptc/ptc_LATISS_RXX_S00_LATISS_calib_DM-46359_isrTaskLSST_lowerSetTemp_ptcGen_20241014a_20241014T181213Z.fits
@@ -1,1 +1,3 @@
-/sdf/data/rubin/repo/main_20210215/LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z/ptc/ptc_LATISS_RXX_S00_LATISS_calib_DM-46359_isrTaskLSST_lowerSetTemp_ptcGen_20241014a_20241014T181213Z.fits
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e4e5d7d5dc0623e4fb6d7909bbf0b404a7f0ec699c73fe9abaa831a7ed32cc0
+size 3597120

--- a/calib/export.yaml
+++ b/calib/export.yaml
@@ -1,0 +1,59 @@
+description: Butler Data Repository Export
+version: 1.0.2
+universe_version: 7
+universe_namespace: daf_butler
+data:
+- type: dimension
+  element: instrument
+  records:
+  - name: LATISS
+    visit_max: 6050123199999
+    visit_system: 2
+    exposure_max: 6050123199999
+    detector_max: 1
+    class_name: lsst.obs.lsst.Latiss
+- type: dimension
+  element: detector
+  records:
+  - instrument: LATISS
+    id: 0
+    full_name: RXX_S00
+    name_in_raft: RXX_S00
+    raft: null
+    purpose: SCIENCE
+- type: collection
+  collection_type: CALIBRATION
+  name: LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptc.20241014a
+- type: collection
+  collection_type: RUN
+  name: LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z
+  host: null
+  timespan_begin: null
+  timespan_end: null
+- type: dataset_type
+  name: ptc
+  dimensions:
+  - instrument
+  - detector
+  storage_class: PhotonTransferCurveDataset
+  is_calibration: true
+- type: dataset
+  dataset_type: ptc
+  run: LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z
+  records:
+  - dataset_id:
+    - !uuid '4602bc4a-03f2-4790-bcf3-684218f95b93'
+    data_id:
+    - instrument: LATISS
+      detector: 0
+    path: LATISS/calib/DM-46359/isrTaskLSST_lowerSetTemp/ptcGen.20241014a/20241014T181213Z/ptc/ptc_LATISS_RXX_S00_LATISS_calib_DM-46359_isrTaskLSST_lowerSetTemp_ptcGen_20241014a_20241014T181213Z.fits
+    formatter: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
+- type: associations
+  collection: LATISS/calib
+  collection_type: CALIBRATION
+  validity_ranges:
+  - timespan: !lsst.daf.butler.Timespan
+      begin: null
+      end: null
+    dataset_ids:
+    - !uuid '4602bc4a-03f2-4790-bcf3-684218f95b93'


### PR DESCRIPTION
Add a PTC, as that is now required for ISR processing on LSST cameras.
